### PR TITLE
Fix RenderPass synchronization hazards.

### DIFF
--- a/external/vulkancts/modules/vulkan/binding_model/vktBindingDescriptorSetRandomTests.cpp
+++ b/external/vulkancts/modules/vulkan/binding_model/vktBindingDescriptorSetRandomTests.cpp
@@ -2020,9 +2020,9 @@ tcu::TestStatus DescriptorSetRandomTestInstance::iterate (void)
 			VK_SUBPASS_EXTERNAL,							// deUint32				srcSubpass
 			0,												// deUint32				dstSubpass
 			VK_PIPELINE_STAGE_TRANSFER_BIT,					// VkPipelineStageFlags	srcStageMask
-			VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,			// VkPipelineStageFlags	dstStageMask
+			VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT | VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT, // dstStageMask
 			VK_ACCESS_TRANSFER_WRITE_BIT,					// VkAccessFlags		srcAccessMask
-			VK_ACCESS_INPUT_ATTACHMENT_READ_BIT | VK_ACCESS_SHADER_READ_BIT,	//	dstAccessMask
+			VK_ACCESS_INPUT_ATTACHMENT_READ_BIT | VK_ACCESS_SHADER_READ_BIT | VK_ACCESS_COLOR_ATTACHMENT_READ_BIT  | VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,	//	dstAccessMask
 			VK_DEPENDENCY_BY_REGION_BIT						// VkDependencyFlags	dependencyFlags
 		};
 


### PR DESCRIPTION
This is a dummy PR between 2 of my branches for review purposes.

This resolve 60,000+ errors from sync validation, all of the form:
Test case 'dEQP-VK.binding_model.descriptorset_random.sets4.noarray.ubolimitlow.sbolimitlow.sampledimglow.outimgonly.noiub.nouab.frag.ialimitlow.0'..
SYNC-HAZARD-READ_AFTER_WRITE(ERROR / SPEC): msgNum: 1287084845 - Validation Error: [ SYNC-HAZARD-READ_AFTER_WRITE ] Object 0: handle = 0x69f1dd000169f1dd, type = VK_OBJECT_TYPE_RENDER_PASS; | MessageID = 0x4cb75b2d | vkCmdBeginRenderPass: Hazard READ_AFTER_WRITE in subpass 0 for attachment 0 aspect color during load with loadOp VK_ATTACHMENT_LOAD_OP_LOAD. Access info (usage: SYNC_COLOR_ATTACHMENT_OUTPUT_COLOR_ATTACHMENT_READ, prior_usage: SYNC_IMAGE_LAYOUT_TRANSITION, write_barriers: SYNC_VERTEX_SHADER_SHADER_READ|SYNC_VERTEX_SHADER_SHADER_WRITE|SYNC_FRAGMENT_SHADER_INPUT_ATTACHMENT_READ|SYNC_FRAGMENT_SHADER_SHADER_READ|SYNC_FRAGMENT_SHADER_SHADER_WRITE|SYNC_COMPUTE_SHADER_SHADER_READ|SYNC_COMPUTE_SHADER_SHADER_WRITE, command: vkCmdPipelineBarrier, seq_no: 6, reset_no: 1).
    Objects: 1
        [0] 0x69f1dd000169f1dd, type: 18, name: NULL


